### PR TITLE
Support zero-shot VQA inference for pretrained OFA ckpt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/*
 .DS_Store
+.vscode

--- a/evaluate.py
+++ b/evaluate.py
@@ -18,6 +18,7 @@ from omegaconf import DictConfig
 
 from utils import checkpoint_utils
 from utils.eval_utils import eval_step, merge_results
+from utils.zero_shot_utils import zero_shot_step
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
@@ -131,7 +132,10 @@ def main(cfg: DictConfig, **kwargs):
         sample = utils.move_to_cuda(sample) if use_cuda else sample
         sample = utils.apply_to_sample(apply_half, sample) if cfg.common.fp16 else sample
         with torch.no_grad():
-            result, scores = eval_step(task, generator, models, sample, **kwargs)
+            if kwargs["zero_shot"]:
+                result, scores = zero_shot_step(task, generator, models, sample)
+            else:
+                result, scores = eval_step(task, generator, models, sample, **kwargs)
         results += result
         score_sum += sum(scores) if scores is not None else 0
         score_cnt += len(scores) if scores is not None else 0

--- a/run_scripts/vqa/evaluate_vqa_zeroshot.sh
+++ b/run_scripts/vqa/evaluate_vqa_zeroshot.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This script evaluates pretrained OFA-Large checkpoint on zero-shot open-domain VQA task.
+
+# The port for communication. Note that if you want to run multiple tasks on the same machine,
+# you need to specify different port numbers.
+export MASTER_PORT=8082
+
+user_dir=../../ofa_module
+bpe_dir=../../utils/BPE
+
+# val or test
+split=$1
+
+data=../../dataset/vqa_data/vqa_${split}.tsv
+path=../../checkpoints/ofa_large.pt
+result_path=../../results/vqa_${split}_zeroshot
+selected_cols=0,5,2,3,4
+
+CUDA_VISIBLE_DEVICES=0,1,2,3 python3 -m torch.distributed.launch --nproc_per_node=4 --master_port=${MASTER_PORT} ../../evaluate.py \
+    ${data} \
+    --path=${path} \
+    --user-dir=${user_dir} \
+    --task=vqa_gen \
+    --selected-cols=${selected_cols} \
+    --bpe-dir=${bpe_dir} \
+    --patch-image-size=480 \
+    --prompt-type='none' \
+    --batch-size=8 \
+    --log-format=simple --log-interval=10 \
+    --seed=7 \
+    --gen-subset=${split} \
+    --results-path=${result_path} \
+    --fp16 \
+    --zero-shot \
+    --beam=20 \
+    --unnormalized \
+    --temperature=1.0 \
+    --num-workers=0 \
+    --model-overrides="{\"data\":\"${data}\",\"bpe_dir\":\"${bpe_dir}\",\"selected_cols\":\"${selected_cols}\"}"


### PR DESCRIPTION
This PR adds a script which performs zero-shot (open-domain) VQA inference for the pretrained OFA checkpoint. The `evaluate.py` file is modified at the same time for compatibility.