### PR TITLE
Fixing attention mask & cache

### DIFF
--- a/transformers/src/transformers/models/ofa/modeling_ofa.py
+++ b/transformers/src/transformers/models/ofa/modeling_ofa.py
@@ -1888,8 +1888,8 @@ class OFAModel(OFAPreTrainedModel):
                 sample_patch_num=sample_patch_num,
             )
 
-        if decoder_input_ids.eq(self.config.pad_token_id).any():
-            attention_mask = decoder_input_ids.eq(self.padding_idx)
+        # if decoder_input_ids.eq(self.config.pad_token_id).any():
+        #     attention_mask = decoder_input_ids.eq(self.padding_idx)
 
         encoder_hidden_states = encoder_outputs.last_hidden_state
         encoder_attention_mask = _expand_mask(
@@ -1953,7 +1953,8 @@ class OFAModel(OFAPreTrainedModel):
             "use_cache": use_cache,
         }
 
-    def prepare_decoder_input_ids_from_labels(self, labels: torch.Tensor):
+    def prepare_decoder_input_ids_from_labels(sel
+    f, labels: torch.Tensor):
         return shift_tokens_right(labels, self.config.pad_token_id, self.config.decoder_start_token_id)
 
     def _prepare_encoder_decoder_kwargs_for_generation(

--- a/transformers/src/transformers/models/ofa/modeling_ofa.py
+++ b/transformers/src/transformers/models/ofa/modeling_ofa.py
@@ -1892,9 +1892,14 @@ class OFAModel(OFAPreTrainedModel):
         #     attention_mask = decoder_input_ids.eq(self.padding_idx)
 
         encoder_hidden_states = encoder_outputs.last_hidden_state
-        encoder_attention_mask = _expand_mask(
+        if past_key_values is not None and len(past_key_values)>0:
+            encoder_attention_mask = _expand_mask(
                 ~encoder_outputs.padding_mask, encoder_hidden_states.dtype, decoder_input_ids[:, -1:].shape[-1]
-        )
+            )
+        else:
+            encoder_attention_mask = _expand_mask(
+                ~encoder_outputs.padding_mask, encoder_hidden_states.dtype, decoder_input_ids.shape[-1]
+            )
         src_pos_embed = encoder_outputs.position_embedding
 
         decoder_outputs = self.decoder(

--- a/transformers/src/transformers/models/ofa/modeling_ofa.py
+++ b/transformers/src/transformers/models/ofa/modeling_ofa.py
@@ -1893,7 +1893,7 @@ class OFAModel(OFAPreTrainedModel):
 
         encoder_hidden_states = encoder_outputs.last_hidden_state
         encoder_attention_mask = _expand_mask(
-            ~encoder_outputs.padding_mask, encoder_hidden_states.dtype, decoder_input_ids.shape[-1]
+                ~encoder_outputs.padding_mask, encoder_hidden_states.dtype, decoder_input_ids[:, -1:].shape[-1]
         )
         src_pos_embed = encoder_outputs.position_embedding
 
@@ -1935,8 +1935,8 @@ class OFAModel(OFAPreTrainedModel):
         attention_mask = decoder_input_ids.new_ones(decoder_input_ids.shape)
 
         # cut decoder_input_ids if past is used
-        if past is not None:
-            decoder_input_ids = decoder_input_ids[:, -1:]
+        # if past is not None:
+        #     decoder_input_ids = decoder_input_ids[:, -1:]
 
         return {
             "input_ids": None,

--- a/transformers/src/transformers/models/ofa/modeling_ofa.py
+++ b/transformers/src/transformers/models/ofa/modeling_ofa.py
@@ -1953,8 +1953,7 @@ class OFAModel(OFAPreTrainedModel):
             "use_cache": use_cache,
         }
 
-    def prepare_decoder_input_ids_from_labels(sel
-    f, labels: torch.Tensor):
+    def prepare_decoder_input_ids_from_labels(self, labels: torch.Tensor):
         return shift_tokens_right(labels, self.config.pad_token_id, self.config.decoder_start_token_id)
 
     def _prepare_encoder_decoder_kwargs_for_generation(


### PR DESCRIPTION
Hello,

Following https://github.com/OFA-Sys/OFA/pull/214#issuecomment-1233919521 and https://github.com/OFA-Sys/OFA/pull/222#event-7310098999, I found another place where the attention mask is wrong (or at least not in the HF format):
```
 if decoder_input_ids.eq(self.config.pad_token_id).any():
            attention_mask = decoder_input_ids.eq(self.padding_idx)
```
Commenting these lines is fine since the attention mask should be fed to the model in the first place. The issue seems to be that this line returns a boolean mask instead of 0s and 1s. Maybe casting it can also works, but I do not think this is good practice to overwrite the attention mask computed before hand. Maybe computing it only if there is none given to the model.

Also, as stated here: https://github.com/OFA-Sys/OFA/issues/171#issuecomment-1245401386, using cache (`use_cache=True`) results in bad (or at least worse) outputs.
I digged into that and found the reason ; while the states are well cached, the `attn_bias` is not the same when using or not the cache since it is computed like so: `self_attn_bias += self.get_rel_pos_bias(all_prev_output_tokens, idx).unsqueeze(0)` which rely on `all_prev_output_tokens`, which, when using cache, is only the last token (when using cache, we only feed the last token as input to the model).
For a quick fix, I changed `prepare_inputs_for_generation` so we have every token as inputs (only the last one is fed to the decoder, since the same line is in the its forward() function. Also adapting the encoder attention mask in case past is used (since it is before processing the input ids).

I take this opportunity to ask again: @JustinLin610, do you plan to release fine-tuned checkpoint for tiny and medium model ? Would be cool for people that want to further train these models and do not have access to a lot of GPUs.