### PR TITLE
fix filedataset index

### DIFF
--- a/data/file_dataset.py
+++ b/data/file_dataset.py
@@ -50,7 +50,7 @@ class FileDataset:
                 self.file_path, self.slice_id))
         else:
             # make an iteration over the file to get row_count and line_idx-to-offset mapping
-            fp = open(self.file_path, "r")
+            fp = open(self.file_path, "rb")
             print("local datafile {} slice_id {} begin to initialize row_count and line_idx-to-offset mapping".format(
                 self.file_path, self.slice_id))
             self.total_row_count = 0
@@ -59,7 +59,7 @@ class FileDataset:
             for line in fp:
                 self.lineid_to_offset.append(offset)
                 self.total_row_count += 1
-                offset += len(line.encode('utf-8'))
+                offset += len(line)
         self._compute_start_pos_and_row_count()
         print("local datafile {} slice_id {} finished initializing row_count and line_idx-to-offset mapping".format(
             self.file_path, self.slice_id))


### PR DESCRIPTION
I ran into an issue with the index generation for FileDataset class. Since the file is not opened with read byte mode, it is adding the wrong line length on line 62. When running with multiple GPUs, it causes readline() to return an incomplete line for some workers. 