### PR TITLE
Update evaluate.py

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -164,7 +164,7 @@ def main(cfg: DictConfig, **kwargs):
                 result, scores = eval_step(
                     task, generator, models, sample, **kwargs)
         results += result
-        if scores and isinstance(scores[0], tuple):
+        if scores is not None and isinstance(scores[0], tuple):
             score_sum += sum([s[0] for s in scores])
             score_cnt += sum([s[1] for s in scores])
         else:


### PR DESCRIPTION
Fix the conditional determination of whether the scores variable is empty.

## problem

When running evaluate_refcoco.sh, encounter errors below.
```bash
scores:tensor([1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
       device='cuda:0')
Traceback (most recent call last):
  File "/home/xxx/projects/OFA/run_scripts/refcoco/../../evaluate.py", line 188, in main
    if scores and isinstance(scores[0], tuple):
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```

## Solution

```python
            # if scores and isinstance(scores[0], tuple):
            if scores is not None and isinstance(scores[0], tuple):
                score_sum += sum([s[0] for s in scores])
                score_cnt += sum([s[1] for s in scores])
```